### PR TITLE
linux-imx: Enable I2C4 in cl-som-imx8 dtb

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-linux-imx-Enable-I2C4-in-cl-som-imx8-dtb.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-linux-imx-Enable-I2C4-in-cl-som-imx8-dtb.patch
@@ -1,0 +1,33 @@
+From 634a31061902d47557b9f89b6ad94633d504d923 Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@balena.io>
+Date: Mon, 16 Dec 2019 12:02:24 +0100
+Subject: [PATCH] linux-imx: Enable I2C4 in cl-som-imx8 dtb
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Sebastian Panceac <sebastian@balena.io>
+---
+ arch/arm64/boot/dts/compulab/cl-som-imx8.dts | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+index 80abe3ef0b94..0cdd0ad4c83b 100644
+--- a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
++++ b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+@@ -76,3 +76,14 @@
+ &wm8731 {
+     status = "okay";
+ };
++
++&pwm2 {
++    status = "disabled";
++};
++
++&i2c4 {
++    clock-frequency = <100000>;
++    pinctrl-names = "default";
++    pinctrl-0 = <&pinctrl_i2c4>;
++    status = "okay";
++};
+-- 
+2.17.1
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -8,6 +8,7 @@ SRC_URI_append = " \
         file://0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
         file://0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
         file://USB3-stability-fix.patch \
+        file://0001-linux-imx-Enable-I2C4-in-cl-som-imx8-dtb.patch \
 "
 
 


### PR DESCRIPTION
Changelog-entry: linux-imx: Enable I2C4 in cl-som-imx8 dtb
Signed-off-by: Sebastian Panceac <sebastian@balena.io>