### PR TITLE
recipes-kernel: Add patch to rotate the touchpanel 180 degrees

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0009-Rotate_180degree_touchpanel_GT911.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0009-Rotate_180degree_touchpanel_GT911.patch
@@ -1,0 +1,30 @@
+From 8ecdb2b7391ab3417413f965d8f53183325ac9ba Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Mon, 18 May 2020 16:36:18 +0200
+Subject: [PATCH] Rotate the GT911 touch panel 180 degrees
+
+The Goodix GT911 touch panel needs to be rotated 180 degrees
+to have it placed correctly over the display
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ arch/arm64/boot/dts/compulab/cl-som-imx8.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+index 786a1f3beed1..99c0a38de01a 100644
+--- a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
++++ b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+@@ -382,6 +382,8 @@
+ 
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pinctrl_i2c4_gt911>;
++		touchscreen-inverted-x = "true";
++		touchscreen-inverted-y = "true";
+ 
+ 		esd-recovery-timeout-ms = <2000>;
+ 		interrupts-extended = GPIRQ_GT911;
+-- 
+2.17.1
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -28,6 +28,7 @@ SRC_URI_append_etcher-pro = " \
 	file://0001-tune-raydium-driver-for-maxen-display.patch \
 	file://0001-enable-maxen-display-in-dt.patch \
 	file://0008-Enable_touchpanel_GT911.patch \
+	file://0009-Rotate_180degree_touchpanel_GT911.patch \
 "
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"


### PR DESCRIPTION
The Goodix GT911 touch panel needs to be rotated 180 degrees
to have it placed correctly over the display

Changelog-entry: Rotate GT911 touchpanel 180 degrees
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>