### PR TITLE
linux-imx: Add debug logs in pci driver, switch i2c speed

### DIFF
--- a/layers/meta-balena-compulab/recipes-bsp/u-boot/patches/0001-update-gpios-to-epv2_3.patch
+++ b/layers/meta-balena-compulab/recipes-bsp/u-boot/patches/0001-update-gpios-to-epv2_3.patch
@@ -1,0 +1,37 @@
+From 20f39c4aef3e438e8f986afcf28a70f05f042aee Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Tue, 28 Jul 2020 15:46:54 +0200
+Subject: [PATCH] update gpios to epv2_3
+
+---
+ board/compulab/cl-som-imx8/cl-som-imx8.c | 13 +++++--------
+ 1 file changed, 5 insertions(+), 8 deletions(-)
+
+diff --git a/board/compulab/cl-som-imx8/cl-som-imx8.c b/board/compulab/cl-som-imx8/cl-som-imx8.c
+index 2a14ceb959..2d881d0059 100644
+--- a/board/compulab/cl-som-imx8/cl-som-imx8.c
++++ b/board/compulab/cl-som-imx8/cl-som-imx8.c
+@@ -336,16 +336,13 @@ int board_init(void)
+ 	gpio_direction_output(IMX_GPIO_NR(4, 5), 1);
+ 
+ 	gpio_request(IMX_GPIO_NR(5, 18),"tft_bcl_pwm");
+-	gpio_direction_output(IMX_GPIO_NR(5, 18), 0);
++	gpio_direction_output(IMX_GPIO_NR(5, 18), 1);
+ 
+-	gpio_request(IMX_GPIO_NR(4, 1),"tft_shlr");
+-	gpio_direction_output(IMX_GPIO_NR(4, 1), 0);
++	gpio_request(IMX_GPIO_NR(5, 4),"pwm_fan");
++	gpio_direction_output(IMX_GPIO_NR(5, 4), 1);
+ 
+-	gpio_request(IMX_GPIO_NR(4, 16),"tft_updw");
+-	gpio_direction_output(IMX_GPIO_NR(4, 16), 1);
+-
+-	gpio_request(IMX_GPIO_NR(3, 25),"tft_rst");
+-	gpio_direction_output(IMX_GPIO_NR(3, 25), 1);
++	gpio_request(IMX_GPIO_NR(4, 7),"uPCIe_1_RST");
++	gpio_direction_output(IMX_GPIO_NR(4, 7), 1);
+ 
+ #if defined(CONFIG_USB_DWC3) || defined(CONFIG_USB_XHCI_IMX8M)
+ 	init_usb_clk();
+-- 
+2.17.1

--- a/layers/meta-balena-compulab/recipes-bsp/u-boot/u-boot-imx_2018.03.bbappend
+++ b/layers/meta-balena-compulab/recipes-bsp/u-boot/u-boot-imx_2018.03.bbappend
@@ -22,4 +22,5 @@ SRC_URI_append_etcher-pro += " \
 	file://0002-Set-video-resolution-1920x1080.patch \
 	file://0003-Set_device_tree_to_sbc-imx8-no-wp.dtb.patch \
 	file://0005-maxen-mipi-display-gpios-configuration.patch \
+	file://0001-update-gpios-to-epv2_3.patch \
 "

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Add-debug-messages.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Add-debug-messages.patch
@@ -1,0 +1,174 @@
+From cde2c49c9ced921c3cdce9747cfad95f6ab341af Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 8 Sep 2020 11:42:57 +0200
+Subject: [PATCH] Add debug messages
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Vicentriu Galanopulo <vicentiu@balena.io>
+---
+ drivers/pci/dwc/pci-imx6.c | 29 +++++++++++++++++++++++++----
+ 1 file changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/dwc/pci-imx6.c b/drivers/pci/dwc/pci-imx6.c
+index 54459b5..6bef772 100644
+--- a/drivers/pci/dwc/pci-imx6.c
++++ b/drivers/pci/dwc/pci-imx6.c
+@@ -1087,8 +1087,10 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 	struct device_node *np;
+ 	void __iomem *base;
+ 
++	printk(KERN_ERR"starting imx_pcie_init_phy\n");
+ 	if (imx_pcie->variant == IMX8QM
+ 			|| imx_pcie->variant == IMX8QXP) {
++		printk(KERN_ERR"starting variant imx8qm\n");
+ 		switch (imx_pcie->hsio_cfg) {
+ 		case PCIEAX2SATA:
+ 			/*
+@@ -1157,7 +1159,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 				IMX8QM_MISC_PCIE_AB_SELECT);
+ 			break;
+ 		}
+-
++		printk(KERN_ERR"imx_pcie->ext_osc\n");
+ 		if (imx_pcie->ext_osc) {
+ 			regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 				IMX8QM_CSR_MISC_OFFSET,
+@@ -1168,6 +1170,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 				IMX8QM_MISC_IOB_TXENA,
+ 				0);
+ 		} else {
++			 printk(KERN_ERR"Try to used the internal pll as ref clk\n");
+ 			/* Try to used the internal pll as ref clk */
+ 			regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 				IMX8QM_CSR_MISC_OFFSET,
+@@ -1185,6 +1188,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 				| IMX8QM_CSR_MISC_IOB_A_0_M1M0_2);
+ 		}
+ 	} else if (imx_pcie->variant == IMX8MQ || imx_pcie->variant == IMX8MM) {
++		printk(KERN_ERR"imx_pcie->variant == IMX8MQ || imx_pcie->variant == IMX8MM\n");
+ 		imx_pcie_phy_pwr_up(imx_pcie);
+ 
+ 		if (imx_pcie->ctrl_id == 0)
+@@ -1193,10 +1197,12 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 			val = IOMUXC_GPR16;
+ 
+ 		if (imx_pcie->ext_osc) {
++			 printk(KERN_ERR"imx_pcie->ext_osc before regmap_update_bits\n");
+ 			regmap_update_bits(imx_pcie->iomuxc_gpr, val,
+ 					IMX8MQ_GPR_PCIE_REF_USE_PAD,
+ 					IMX8MQ_GPR_PCIE_REF_USE_PAD);
+ 			if (imx_pcie->variant == IMX8MM) {
++				 printk(KERN_ERR"variant == imx8mm\n");
+ 				dev_info(imx_pcie->pci->dev,
+ 					"Initialize PHY with EXT REfCLK!.\n");
+ 				regmap_update_bits(imx_pcie->iomuxc_gpr, val,
+@@ -1227,7 +1233,9 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 					"PHY Initialization End!.\n");
+ 			}
+ 		} else {
++		       printk(KERN_ERR"ELSE imx_pcie->ext_osc\n");
+ 			if (imx_pcie->variant == IMX8MM) {
++				printk(KERN_ERR"variant = imx8mm\n");
+ 				/* Configure the internal PLL as REF clock */
+ 				dev_info(imx_pcie->pci->dev,
+ 					"Initialize PHY with PLL REfCLK!.\n");
+@@ -1264,6 +1272,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 				dev_info(imx_pcie->pci->dev,
+ 					"PHY Initialization End!.\n");
+ 			} else {
++				printk(KERN_ERR"for the rest of the IMX variants mq...\n");
+ 				np = of_find_compatible_node(NULL, NULL,
+ 						"fsl,imx8mq-anatop");
+ 				base = of_iomap(np, 0);
+@@ -1288,12 +1297,14 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 		 * Configure the TRSV regiser of iMX8MM PCIe PHY.
+ 		 */
+ 		if (imx_pcie->variant == IMX8MM) {
++			printk(KERN_ERR"In order to pass the compliance tests\n");
+ 			writel(PCIE_PHY_TRSV_REG5_GEN1_DEEMP,
+ 			       imx_pcie->phy_base + PCIE_PHY_TRSV_REG5);
+ 			writel(PCIE_PHY_TRSV_REG6_GEN2_DEEMP,
+ 			       imx_pcie->phy_base + PCIE_PHY_TRSV_REG6);
+ 		}
+ 	} else if (imx_pcie->variant == IMX7D) {
++		printk(KERN_ERR"imx_pcie->variant IMX7D\n");
+ 		/* Enable PCIe PHY 1P0D */
+ 		regulator_set_voltage(imx_pcie->pcie_phy_regulator,
+ 				1000000, 1000000);
+@@ -1306,6 +1317,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
+ 				   IMX7D_GPR12_PCIE_PHY_REFCLK_SEL, 0);
+ 	} else if (imx_pcie->variant == IMX6SX) {
++		printk(KERN_ERR"imx_pcie->variant IMX6SX\n");
+ 		/* Force PCIe PHY reset */
+ 		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR5,
+ 				IMX6SX_GPR5_PCIE_BTNRST_RESET,
+@@ -1323,6 +1335,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 	}
+ 
+ 	if (imx_pcie->pcie_bus_regulator != NULL) {
++	printk(KERN_ERR"pcie_bus_regulator not null\n");
+ 		ret = regulator_enable(imx_pcie->pcie_bus_regulator);
+ 		if (ret)
+ 			dev_err(imx_pcie->pci->dev, "failed to enable pcie regulator.\n");
+@@ -1332,7 +1345,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 					  || (imx_pcie->variant == IMX6SX)) {
+ 		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
+ 				   IMX6Q_GPR12_PCIE_CTL_2, 0 << 10);
+-
++		printk(KERN_ERR"imx_pcie->variant IMX6Sq/qp/6sx\n");
+ 		/* configure constant input signal to the pcie ctrl and phy */
+ 		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
+ 				   IMX6Q_GPR12_LOS_LEVEL, IMX6Q_GPR12_LOS_LEVEL_9);
+@@ -1356,14 +1369,17 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 
+ 	/* configure the device type */
+ 	if (IS_ENABLED(CONFIG_EP_MODE_IN_EP_RC_SYS)) {
++		printk(KERN_ERR"IS_ENABLED(CONFIG_EP_MODE_IN_EP_RC_SYS)\n");
+ 		if (imx_pcie->variant == IMX8QM
+ 				|| imx_pcie->variant == IMX8QXP) {
++			printk(KERN_ERR"imx_pcie->variant == IMX8QM/IMX8QXP\n");
+ 			val = IMX8QM_CSR_PCIEA_OFFSET
+ 				+ imx_pcie->ctrl_id * SZ_64K;
+ 			regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 					val, IMX8QM_PCIE_TYPE_MASK,
+ 					PCI_EXP_TYPE_ENDPOINT << 24);
+ 		} else {
++			printk(KERN_ERR"unlikely(imx_pcie->ctrl_id)\n");
+ 			if (unlikely(imx_pcie->ctrl_id))
+ 				/* iMX8MQ second PCIE */
+ 				regmap_update_bits(imx_pcie->iomuxc_gpr,
+@@ -1379,23 +1395,28 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 	} else {
+ 		if (imx_pcie->variant == IMX8QM
+ 				|| imx_pcie->variant == IMX8QXP) {
++			printk(KERN_ERR" ON ELSE imx_pcie->variant == IMX8QM/IMX8QXP\n");
+ 			val = IMX8QM_CSR_PCIEA_OFFSET
+ 				+ imx_pcie->ctrl_id * SZ_64K;
+ 			regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 					val, IMX8QM_PCIE_TYPE_MASK,
+ 					PCI_EXP_TYPE_ROOT_PORT << 24);
+ 		} else {
+-			if (unlikely(imx_pcie->ctrl_id))
++			printk(KERN_ERR"ELSE unlikely(imx_pcie->ctrl_id)\n");
++			if (unlikely(imx_pcie->ctrl_id)) {
+ 				/* iMX8MQ second PCIE */
++				printk(KERN_ERR"iMX8MQ second PCIE\n");
+ 				regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 						IOMUXC_GPR12,
+ 						IMX6Q_GPR12_DEVICE_TYPE >> 4,
+ 						PCI_EXP_TYPE_ROOT_PORT << 8);
+-			else
++			} else {
++				printk(KERN_ERR"ELSE iMX8MQ second PCIE\n");
+ 				regmap_update_bits(imx_pcie->iomuxc_gpr,
+ 						IOMUXC_GPR12,
+ 						IMX6Q_GPR12_DEVICE_TYPE,
+ 						PCI_EXP_TYPE_ROOT_PORT << 12);
++			}
+ 		}
+ 	}
+ }
+-- 
+2.7.4
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Add-debug-messages.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Add-debug-messages.patch
@@ -1,78 +1,77 @@
-From cde2c49c9ced921c3cdce9747cfad95f6ab341af Mon Sep 17 00:00:00 2001
-From: Alexandru Costache <alexandru@balena.io>
-Date: Tue, 8 Sep 2020 11:42:57 +0200
-Subject: [PATCH] Add debug messages
+From e05491bbff67be7003893a4b0236bfcfffea5687 Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Fri, 4 Sep 2020 17:22:01 +0200
+Subject: [PATCH] debug_messages
 
-Upstream-status: Inappropriate [configuration]
-Signed-off-by: Vicentriu Galanopulo <vicentiu@balena.io>
 ---
- drivers/pci/dwc/pci-imx6.c | 29 +++++++++++++++++++++++++----
- 1 file changed, 25 insertions(+), 4 deletions(-)
+ drivers/pci/dwc/pci-imx6.c | 34 ++++++++++++++++++++++++++++++----
+ 1 file changed, 30 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/pci/dwc/pci-imx6.c b/drivers/pci/dwc/pci-imx6.c
-index 54459b5..6bef772 100644
+index 54459b52f526..3033b97f1bd9 100644
 --- a/drivers/pci/dwc/pci-imx6.c
 +++ b/drivers/pci/dwc/pci-imx6.c
-@@ -1087,8 +1087,10 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1087,8 +1087,11 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  	struct device_node *np;
  	void __iomem *base;
  
 +	printk(KERN_ERR"starting imx_pcie_init_phy\n");
  	if (imx_pcie->variant == IMX8QM
  			|| imx_pcie->variant == IMX8QXP) {
-+		printk(KERN_ERR"starting variant imx8qm\n");
++
++	printk(KERN_ERR"starting variant imx8qm\n");
  		switch (imx_pcie->hsio_cfg) {
  		case PCIEAX2SATA:
  			/*
-@@ -1157,7 +1159,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
- 				IMX8QM_MISC_PCIE_AB_SELECT);
- 			break;
+@@ -1159,6 +1162,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  		}
--
-+		printk(KERN_ERR"imx_pcie->ext_osc\n");
+ 
  		if (imx_pcie->ext_osc) {
++			printk(KERN_ERR"imx_pcie->ext_osc\n");
  			regmap_update_bits(imx_pcie->iomuxc_gpr,
  				IMX8QM_CSR_MISC_OFFSET,
-@@ -1168,6 +1170,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+ 				IMX8QM_MISC_IOB_RXENA,
+@@ -1168,6 +1172,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  				IMX8QM_MISC_IOB_TXENA,
  				0);
  		} else {
-+			 printk(KERN_ERR"Try to used the internal pll as ref clk\n");
++			printk(KERN_ERR"Try to used the internal pll as ref clk\n");
  			/* Try to used the internal pll as ref clk */
  			regmap_update_bits(imx_pcie->iomuxc_gpr,
  				IMX8QM_CSR_MISC_OFFSET,
-@@ -1185,6 +1188,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1185,6 +1190,8 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  				| IMX8QM_CSR_MISC_IOB_A_0_M1M0_2);
  		}
  	} else if (imx_pcie->variant == IMX8MQ || imx_pcie->variant == IMX8MM) {
++
 +		printk(KERN_ERR"imx_pcie->variant == IMX8MQ || imx_pcie->variant == IMX8MM\n");
  		imx_pcie_phy_pwr_up(imx_pcie);
  
  		if (imx_pcie->ctrl_id == 0)
-@@ -1193,10 +1197,12 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1193,10 +1200,12 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  			val = IOMUXC_GPR16;
  
  		if (imx_pcie->ext_osc) {
-+			 printk(KERN_ERR"imx_pcie->ext_osc before regmap_update_bits\n");
++			printk(KERN_ERR"imx_pcie->ext_osc before regmap_update_bits\n");
  			regmap_update_bits(imx_pcie->iomuxc_gpr, val,
  					IMX8MQ_GPR_PCIE_REF_USE_PAD,
  					IMX8MQ_GPR_PCIE_REF_USE_PAD);
  			if (imx_pcie->variant == IMX8MM) {
-+				 printk(KERN_ERR"variant == imx8mm\n");
++				printk(KERN_ERR"variant == imx8mm\n");
  				dev_info(imx_pcie->pci->dev,
  					"Initialize PHY with EXT REfCLK!.\n");
  				regmap_update_bits(imx_pcie->iomuxc_gpr, val,
-@@ -1227,7 +1233,9 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1227,7 +1236,9 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  					"PHY Initialization End!.\n");
  			}
  		} else {
-+		       printk(KERN_ERR"ELSE imx_pcie->ext_osc\n");
++			printk(KERN_ERR"ELSE imx_pcie->ext_osc\n");
  			if (imx_pcie->variant == IMX8MM) {
-+				printk(KERN_ERR"variant = imx8mm\n");
++			printk(KERN_ERR"variant = imx8mm\n");
  				/* Configure the internal PLL as REF clock */
  				dev_info(imx_pcie->pci->dev,
  					"Initialize PHY with PLL REfCLK!.\n");
-@@ -1264,6 +1272,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1264,6 +1275,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  				dev_info(imx_pcie->pci->dev,
  					"PHY Initialization End!.\n");
  			} else {
@@ -80,7 +79,7 @@ index 54459b5..6bef772 100644
  				np = of_find_compatible_node(NULL, NULL,
  						"fsl,imx8mq-anatop");
  				base = of_iomap(np, 0);
-@@ -1288,12 +1297,14 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1288,12 +1300,14 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  		 * Configure the TRSV regiser of iMX8MM PCIe PHY.
  		 */
  		if (imx_pcie->variant == IMX8MM) {
@@ -95,23 +94,24 @@ index 54459b5..6bef772 100644
  		/* Enable PCIe PHY 1P0D */
  		regulator_set_voltage(imx_pcie->pcie_phy_regulator,
  				1000000, 1000000);
-@@ -1306,6 +1317,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1306,6 +1320,8 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
  				   IMX7D_GPR12_PCIE_PHY_REFCLK_SEL, 0);
  	} else if (imx_pcie->variant == IMX6SX) {
++
 +		printk(KERN_ERR"imx_pcie->variant IMX6SX\n");
  		/* Force PCIe PHY reset */
  		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR5,
  				IMX6SX_GPR5_PCIE_BTNRST_RESET,
-@@ -1323,6 +1335,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1323,6 +1339,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  	}
  
  	if (imx_pcie->pcie_bus_regulator != NULL) {
-+	printk(KERN_ERR"pcie_bus_regulator not null\n");
++		printk(KERN_ERR"pcie_bus_regulator not null\n");
  		ret = regulator_enable(imx_pcie->pcie_bus_regulator);
  		if (ret)
  			dev_err(imx_pcie->pci->dev, "failed to enable pcie regulator.\n");
-@@ -1332,7 +1345,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1332,7 +1349,7 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  					  || (imx_pcie->variant == IMX6SX)) {
  		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
  				   IMX6Q_GPR12_PCIE_CTL_2, 0 << 10);
@@ -120,14 +120,14 @@ index 54459b5..6bef772 100644
  		/* configure constant input signal to the pcie ctrl and phy */
  		regmap_update_bits(imx_pcie->iomuxc_gpr, IOMUXC_GPR12,
  				   IMX6Q_GPR12_LOS_LEVEL, IMX6Q_GPR12_LOS_LEVEL_9);
-@@ -1356,14 +1369,17 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1356,14 +1373,17 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  
  	/* configure the device type */
  	if (IS_ENABLED(CONFIG_EP_MODE_IN_EP_RC_SYS)) {
 +		printk(KERN_ERR"IS_ENABLED(CONFIG_EP_MODE_IN_EP_RC_SYS)\n");
  		if (imx_pcie->variant == IMX8QM
  				|| imx_pcie->variant == IMX8QXP) {
-+			printk(KERN_ERR"imx_pcie->variant == IMX8QM/IMX8QXP\n");
++	    printk(KERN_ERR"imx_pcie->variant == IMX8QM/IMX8QXP\n");
  			val = IMX8QM_CSR_PCIEA_OFFSET
  				+ imx_pcie->ctrl_id * SZ_64K;
  			regmap_update_bits(imx_pcie->iomuxc_gpr,
@@ -138,7 +138,7 @@ index 54459b5..6bef772 100644
  			if (unlikely(imx_pcie->ctrl_id))
  				/* iMX8MQ second PCIE */
  				regmap_update_bits(imx_pcie->iomuxc_gpr,
-@@ -1379,23 +1395,28 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
+@@ -1379,23 +1399,29 @@ static void imx_pcie_init_phy(struct imx_pcie *imx_pcie)
  	} else {
  		if (imx_pcie->variant == IMX8QM
  				|| imx_pcie->variant == IMX8QXP) {
@@ -157,9 +157,11 @@ index 54459b5..6bef772 100644
  				regmap_update_bits(imx_pcie->iomuxc_gpr,
  						IOMUXC_GPR12,
  						IMX6Q_GPR12_DEVICE_TYPE >> 4,
- 						PCI_EXP_TYPE_ROOT_PORT << 8);
+-						PCI_EXP_TYPE_ROOT_PORT << 8);
 -			else
-+			} else {
++						PCI_EXP_TYPE_ROOT_PORT << 8); 
++			}
++			else {
 +				printk(KERN_ERR"ELSE iMX8MQ second PCIE\n");
  				regmap_update_bits(imx_pcie->iomuxc_gpr,
  						IOMUXC_GPR12,
@@ -170,5 +172,5 @@ index 54459b5..6bef772 100644
  	}
  }
 -- 
-2.7.4
+2.17.1
 

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Remove-reset-pin-from-GT911.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-Remove-reset-pin-from-GT911.patch
@@ -1,0 +1,24 @@
+From 83e38ea4bd3f82e844036b69a3eb66b21b489454 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Thu, 10 Sep 2020 11:21:57 +0200
+Subject: [PATCH] Remove reset pin from GT911
+
+---
+ arch/arm64/boot/dts/compulab/cl-som-imx8.dts | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+index 63bc7e3..44907d0 100644
+--- a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
++++ b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+@@ -388,7 +388,6 @@
+ 		esd-recovery-timeout-ms = <2000>;
+ 		interrupts-extended = GPIRQ_GT911;
+ 		irq-gpios = GP_GT911_IRQ;
+-		reset-gpios = GP_GT911_RESET;
+ 		status = "okay";
+ 	};
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-disable-reset-pcie.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-disable-reset-pcie.patch
@@ -1,0 +1,53 @@
+From 43ab0ac0501c1a1bcb46fca6f8f7d816c1993e03 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Tue, 8 Sep 2020 15:57:53 +0200
+Subject: [PATCH] dts changes
+
+---
+ arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi | 5 ++---
+ arch/arm64/boot/dts/compulab/sb-imx8.dtsi         | 4 ++--
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+index bdbafd4..6700fd6 100644
+--- a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
++++ b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+@@ -392,7 +392,7 @@
+ 
+ 		pinctrl_wdog: wdoggrp {
+ 			fsl,pins = <
+-				MX8MQ_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B 0xc6
++				MX8MQ_IOMUXC_GPIO1_IO02_WDOG1_WDOG_B 0x6
+ 			>;
+ 		};
+ 	};
+@@ -683,8 +683,7 @@
+ &wdog1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_wdog>;
+-	fsl,ext-reset-output;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &mu {
+diff --git a/arch/arm64/boot/dts/compulab/sb-imx8.dtsi b/arch/arm64/boot/dts/compulab/sb-imx8.dtsi
+index 5d83223..ab2272a 100644
+--- a/arch/arm64/boot/dts/compulab/sb-imx8.dtsi
++++ b/arch/arm64/boot/dts/compulab/sb-imx8.dtsi
+@@ -159,10 +159,10 @@ sbc_i2c_lvds: &i2c2 {
+ 	status = "okay";
+ };
+ 
+-&pcie0 {
++/* &pcie0 {
+ 	reset-gpio = <&pca9555 0 GPIO_ACTIVE_LOW>;
+ 	status = "okay";
+-};
++};*/
+ 
+ &uart1 { /* rs-485 */
+ 	pinctrl-names = "default";
+-- 
+2.7.4
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-test.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-test.patch
@@ -1,0 +1,25 @@
+From ba509ff5052936750931f70142a4f3f705a61cb0 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Thu, 10 Sep 2020 14:30:33 +0200
+Subject: [PATCH] test
+
+---
+ arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+index 6700fd6..d43bfa8 100644
+--- a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
++++ b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+@@ -176,8 +176,6 @@
+ 			fsl,pins = <
+ 				MX8MQ_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x16
+ 				MX8MQ_IOMUXC_GPIO1_IO13_GPIO1_IO13	0x16
+-				MX8MQ_IOMUXC_UART4_TXD_GPIO5_IO29 	0x16
+-				MX8MQ_IOMUXC_UART4_RXD_GPIO5_IO28 	0x16
+ 			>;
+ 		};
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -30,6 +30,7 @@ SRC_URI_append_etcher-pro = " \
 	file://0008-Enable_touchpanel_GT911.patch \
 	file://0009-Rotate_180degree_touchpanel_GT911.patch \
 	file://0010-change_i2c4_clock_freq_400kHz.patch \
+	file://0001-Add-debug-messages.patch \
 "
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -32,6 +32,7 @@ SRC_URI_append_etcher-pro = " \
 	file://0010-change_i2c4_clock_freq_400kHz.patch \
 	file://0001-disable-reset-pcie.patch \
 	file://0001-Remove-reset-pin-from-GT911.patch \
+	file://0001-test.patch \
 "
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"
@@ -67,7 +68,7 @@ RESIN_CONFIGS[pca9956b] = " \
 "
 
 RESIN_CONFIGS[ksz9893r] = " \
-    CONFIG_MICROCHIP_KSZ9893R=y \
+    CONFIG_MICROCHIP_KSZ9893R=m \
 "
 
 RESIN_CONFIGS_append_etcher-pro = " maxen_display"

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -30,8 +30,11 @@ SRC_URI_append_etcher-pro = " \
 	file://0008-Enable_touchpanel_GT911.patch \
 	file://0009-Rotate_180degree_touchpanel_GT911.patch \
 	file://0010-change_i2c4_clock_freq_400kHz.patch \
-	file://0001-Add-debug-messages.patch \
+	file://0001-disable-reset-pcie.patch \
 "
+
+# Let's try only with the pcie0 reset disaled, without the logs
+#       file://0001-Add-debug-messages.patch
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"
 

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -65,7 +65,7 @@ RESIN_CONFIGS[schedutil] = " \
 
 RESIN_CONFIGS_append_etcher-pro = " pca9956b ksz9893r"
 RESIN_CONFIGS[pca9956b] = " \
-    CONFIG_LEDS_PCA9956B=y \
+    CONFIG_LEDS_PCA9956B=m \
 "
 
 RESIN_CONFIGS[ksz9893r] = " \

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -31,10 +31,8 @@ SRC_URI_append_etcher-pro = " \
 	file://0009-Rotate_180degree_touchpanel_GT911.patch \
 	file://0010-change_i2c4_clock_freq_400kHz.patch \
 	file://0001-disable-reset-pcie.patch \
+	file://0001-Remove-reset-pin-from-GT911.patch \
 "
-
-# Let's try only with the pcie0 reset disaled, without the logs
-#       file://0001-Add-debug-messages.patch
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"
 
@@ -65,7 +63,7 @@ RESIN_CONFIGS[schedutil] = " \
 
 RESIN_CONFIGS_append_etcher-pro = " pca9956b ksz9893r"
 RESIN_CONFIGS[pca9956b] = " \
-    CONFIG_LEDS_PCA9956B=m \
+    CONFIG_LEDS_PCA9956B=y \
 "
 
 RESIN_CONFIGS[ksz9893r] = " \


### PR DESCRIPTION
This is a test PR for adding the logs from Vicentiu.
We also switch back i2c4 clock to 100kHz to see if
it has any influence on leds/eth.

Signed-off-by: Alexandru Costache <alexandru@balena.io>