### PR TITLE
recipes-support: fan-control script updates for entering sleep mode

### DIFF
--- a/layers/meta-balena-compulab/recipes-support/fan-control/files/fan-control
+++ b/layers/meta-balena-compulab/recipes-support/fan-control/files/fan-control
@@ -3,31 +3,54 @@ set -e
 
 echo "CPU FAN PWM controlled depending on CPU temperature"
 
-GV='/sys/devices/system/cpu/cpu0/cpufreq'
-PWM_FAN='/sys/class/pwm/pwmchip1/'
-echo userspace > ${GV}/scaling_governor
-LIMIT=65
+PWM_FAN='/sys/class/pwm/pwmchip1'
 
-echo 0 > ${PWM_FAN}/export
+LIMIT=65 #temperature limit
+TIMEOUT=60 #seconds that the fan will run when entering sleep mode
+
+if [ ! -d /sys/class/pwm/pwmchip1/pwm0 ]; then
+    echo 0 > ${PWM_FAN}/export;
+fi
 
 while [ 1 ]
 do
     TEMP=$(sed 's/000$//g'  < /sys/class/thermal/thermal_zone0/temp)
-    if [[ ${TEMP} -gt ${LIMIT} ]]
-    then
-	if [ -d "${PWM_FAN}/pwm0" ]; then
-		echo 45000 > ${PWM_FAN}/pwm0/period
-		echo 45000 > ${PWM_FAN}/pwm0/duty_cycle
-		echo 1 > ${PWM_FAN}/pwm0/enable
+    CPU1_ONLINE=$(cat /sys/devices/system/cpu/cpu1/online)
+
+    if [ ${CPU1_ONLINE} -eq 0 ] && [ ${TIMEOUT} -gt 0 ]; then
+	TIMEOUT=$((TIMEOUT-1))
+	if [[ ${TIMEOUT} -eq 0 ]]; then
+		echo 0 > ${PWM_FAN}/pwm0/duty_cycle
+		echo 1 > ${PWM_FAN}/pwm0/period
+	else
+		DUTY_CYCLE=$(cat ${PWM_FAN}/pwm0/duty_cycle)
+		if [[ ! ${DUTY_CYCLE} -eq 45000 ]]; then
+			echo 45000 > ${PWM_FAN}/pwm0/period
+			echo 45000 > ${PWM_FAN}/pwm0/duty_cycle
+			echo 1 > ${PWM_FAN}/pwm0/enable
+		fi
 	fi
-    else
-	if [ -d "${PWM_FAN}/pwm0" ]; then
-		echo 45000 > ${PWM_FAN}/pwm0/period
-		echo 6000 > ${PWM_FAN}/pwm0/duty_cycle
-		echo 1 > ${PWM_FAN}/pwm0/enable
+    fi
+
+    if [ ${CPU1_ONLINE} -eq 1 ]; then
+	TIMEOUT=60
+	if [ ${TEMP} -gt ${LIMIT} ]
+	then
+		if [ -d "${PWM_FAN}/pwm0" ]; then
+			echo 45000 > ${PWM_FAN}/pwm0/period
+			echo 45000 > ${PWM_FAN}/pwm0/duty_cycle
+			echo 1 > ${PWM_FAN}/pwm0/enable
+		fi
+	else
+		if [ -d "${PWM_FAN}/pwm0" ]; then
+			echo 45000 > ${PWM_FAN}/pwm0/period
+			echo 6000 > ${PWM_FAN}/pwm0/duty_cycle
+			echo 1 > ${PWM_FAN}/pwm0/enable
+		fi
 	fi
     fi
     sleep 1
+
 done
 
 exit 0


### PR DESCRIPTION
Check if the application has set sleep mode and
run the CPU FAN for 60 seconds

Changelog-entry: Add 60 seconds fan cooling when entering sleep mode
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>