### PR TITLE
resin-init-board: Change PWM backlight duty cycle for the MIPI display

### DIFF
--- a/layers/meta-balena-compulab/recipes-support/resin-init/resin-init-board/resin-init-board
+++ b/layers/meta-balena-compulab/recipes-support/resin-init/resin-init-board/resin-init-board
@@ -11,9 +11,10 @@ then
   if [ -d /sys/class/pwm/pwmchip2/pwm0 ]
   then
     echo 45000 > /sys/class/pwm/pwmchip2/pwm0/period
-    echo 45000 > /sys/class/pwm/pwmchip2/pwm0/duty_cycle
+    echo 2500 > /sys/class/pwm/pwmchip2/pwm0/duty_cycle
     echo 1 > /sys/class/pwm/pwmchip2/pwm0/enable
   fi
 fi
 
 exit 0
+


### PR DESCRIPTION
The B70HM30-TNX15 (production display) PWM backlight
operates properly on a lower value for the duty cycle.
Set the value to 2500 to reduce the risk of damage in time

Changelog-entry: Set MIPI display backlight PWM duty cycle to 2500
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>