### PR TITLE
linux-imx: Remove CONFIG_RTC_HCTOSYS and CONFIG_RTC_SYSTOHC

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0020-Disable-internal-imx-RTC-and-external-i2c-RTC.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0020-Disable-internal-imx-RTC-and-external-i2c-RTC.patch
@@ -1,0 +1,50 @@
+From 564a859ce389d03a8beb2124d8665a6ad176a310 Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Thu, 14 Jan 2021 07:51:11 +0100
+Subject: [PATCH] Disable internal imx RTC and external i2c RTC
+
+The current hardware setup for the EP does not contain a coin
+battery for the internal RTC on the SoM. The system queries the
+device created by the RTC and the retrieved date and time value
+is used by chronyd. This leads to chronyd using wrong (default)
+date and time value from the RTC. To fix this the internal RTC
+will be disabled.
+
+On the EP board we don't have an external RTC on i2c, so that
+needs to be disabled.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+
+---
+ arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi | 1 +
+ arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+index c3de992e9d3a..e9db68b57789 100644
+--- a/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
++++ b/arch/arm64/boot/dts/compulab/compulab-imx8mq.dtsi
+@@ -532,6 +532,7 @@
+ 	em3027: rtc@56 {
+ 		compatible = "emmicro,em3027";
+ 		reg = <0x56>;
++		status = "disabled";
+ 	};
+ };
+ 
+diff --git a/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi b/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi
+index 0fc42771052b..c7ec0f734ad9 100755
+--- a/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi
++++ b/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi
+@@ -713,6 +713,7 @@
+ 			offset = <0x34>;
+ 			interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>,
+ 				<GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
++			status = "disabled";
+ 		};
+ 
+ 		snvs_pwrkey: snvs-powerkey {
+-- 
+2.17.1
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -36,6 +36,7 @@ SRC_URI_append_etcher-pro = " \
 	file://0017-Remove-uart1-dts-reference-and-change-pad-and-pad-va.patch \
 	file://0018-Enable-UART1-node.patch \
 	file://0019-Add-kernel-5.x-mainline-KSZ9893-switch-support.patch \
+	file://0020-Disable-internal-imx-RTC-and-external-i2c-RTC.patch \
 "
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -43,7 +43,7 @@ KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"
 # Disable commit SHA in kernel version string
 SCMVERSION="n"
 
-RESIN_CONFIGS_append = " 80211 iwlwifi overlayfs debug_preempt_disable schedutil"
+RESIN_CONFIGS_append = " 80211 iwlwifi overlayfs debug_preempt_disable schedutil rtc_configs"
 RESIN_CONFIGS[80211] = " \
     CONFIG_CFG80211=y \
 "
@@ -81,6 +81,12 @@ RESIN_CONFIGS[dsa] = " \
     CONFIG_NET_DSA_MICROCHIP_KSZ_COMMON=y \
     CONFIG_NET_DSA_MICROCHIP_KSZ9477=y \
     CONFIG_NET_DSA_MICROCHIP_KSZ9477_I2C=y \
+"
+
+RESIN_CONFIGS_append_etcher-pro = " rtc_configs"
+RESIN_CONFIGS[rtc_configs] = " \
+    CONFIG_RTC_HCTOSYS=n \
+    CONFIG_RTC_SYSTOHC=n \
 "
 
 do_configure_prepend_etcher-pro () {


### PR DESCRIPTION
These kernel configs allow setting of the RTC which
has a wrong initial value and may be conflicting with
the timeinit-rtc.sh script and chronyd

Reported error
[timeinit-rtc.sh][INFO] System time is already set
[timeinit-rtc.sh][WARN] RTC time is in the past
[timeinit-rtc.sh][WARN] Check RTC battery if this issue persists
[timeinit-rtc.sh][WARN] RTC time    Tue Feb  1 00.00.10 UTC 2000
[timeinit-rtc.sh][WARN] System time Mon Dec  7 05.11.18 UTC 2020

Changelog-entry: Remove CONFIG_RTC_HCTOSYS and CONFIG_RTC_SYSTOHC
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>