### PR TITLE
fan-control: Remove set of period and duty_cycle when OFF

### DIFF
--- a/layers/meta-balena-compulab/recipes-support/fan-control/files/fan-control
+++ b/layers/meta-balena-compulab/recipes-support/fan-control/files/fan-control
@@ -27,8 +27,6 @@ do
 
 	if [ ${TEMP} -le ${TEMP_STOP} ]; then
 		if [ -d "${PWM_FAN}/pwm0" ]; then
-			echo 1 > ${PWM_FAN}/pwm0/period
-			echo 0 > ${PWM_FAN}/pwm0/duty_cycle
 			echo 0 > ${PWM_FAN}/pwm0/enable
 		fi
 	fi


### PR DESCRIPTION
Setting the period and duty_cycle of the PWM is not needed
in the OFF state of the CPU FAN

Changelog-entry: fan-control: Remove set of period and duty_cycle when OFF
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>