### PR TITLE
linux-imx: goodix touch panel - add support for ESD

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0021-Input-goodix-add-support-for-ESD.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0021-Input-goodix-add-support-for-ESD.patch
@@ -1,0 +1,294 @@
+From e8c7ed7b0103fbb8056bd14223e77046dacbd1b1 Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Mon, 22 Mar 2021 11:20:42 +0100
+Subject: [PATCH] Input: goodix - add support for ESD
+
+Add ESD (Electrostatic Discharge) protection mechanism.
+
+The driver enables ESD protection in HW and checks a register
+to determine if ESD occurred. If ESD is signalled by the HW,
+the driver will reset the device.
+
+The ESD poll time (in ms) can be set through
+esd-recovery-timeout-ms ACPI/DT property. If it is set to 0,
+ESD protection is disabled.
+
+Signed-off-by: Irina Tirdea <irina.tirdea@intel.com>
+
+Upstream-status: Inappropriate [Backport]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ .../bindings/input/touchscreen/goodix.txt     |   5 +
+ drivers/input/touchscreen/goodix.c            | 162 +++++++++++++++++-
+ 2 files changed, 162 insertions(+), 5 deletions(-)
+
+diff --git a/Documentation/devicetree/bindings/input/touchscreen/goodix.txt b/Documentation/devicetree/bindings/input/touchscreen/goodix.txt
+index c98757a69110..7c0a96654431 100644
+--- a/Documentation/devicetree/bindings/input/touchscreen/goodix.txt
++++ b/Documentation/devicetree/bindings/input/touchscreen/goodix.txt
+@@ -19,6 +19,11 @@ Optional properties:
+ 			  interrupt gpio pin as output to reset the device.
+  - reset-gpios		: GPIO pin used for reset
+ 
++ - esd-recovery-timeout-ms : ESD poll time (in milli seconds) for the driver to
++				check if ESD occurred and in that case reset the
++				device. ESD is disabled if this property is not set
++				or is set to 0.
++
+  - touchscreen-inverted-x  : X axis is inverted (boolean)
+  - touchscreen-inverted-y  : Y axis is inverted (boolean)
+  - touchscreen-swapped-x-y : X and Y axis are swapped (boolean)
+diff --git a/drivers/input/touchscreen/goodix.c b/drivers/input/touchscreen/goodix.c
+index 2bfa89ec552c..ed8aa90cc351 100644
+--- a/drivers/input/touchscreen/goodix.c
++++ b/drivers/input/touchscreen/goodix.c
+@@ -49,10 +49,13 @@ struct goodix_ts_data {
+ 	const char *cfg_name;
+ 	struct completion firmware_loading_complete;
+ 	unsigned long irq_flags;
++	atomic_t esd_timeout;
++	struct delayed_work esd_work;
+ };
+ 
+ #define GOODIX_GPIO_INT_NAME		"irq"
+ #define GOODIX_GPIO_RST_NAME		"reset"
++#define GOODIX_DEVICE_ESD_TIMEOUT_PROPERTY		"esd-recovery-timeout-ms"
+ 
+ #define GOODIX_MAX_HEIGHT		4096
+ #define GOODIX_MAX_WIDTH		4096
+@@ -67,6 +70,8 @@ struct goodix_ts_data {
+ /* Register defines */
+ #define GOODIX_REG_COMMAND		0x8040
+ #define GOODIX_CMD_SCREEN_OFF		0x05
++#define GOODIX_CMD_ESD_ENABLED		0xAA
++#define GOODIX_REG_ESD_CHECK		0x8041
+ 
+ #define GOODIX_READ_COOR_ADDR		0x814E
+ #define GOODIX_REG_CONFIG_DATA		0x8047
+@@ -457,6 +462,119 @@ static int goodix_reset(struct goodix_ts_data *ts)
+ 	return 0;
+ }
+ 
++static void goodix_disable_esd(struct goodix_ts_data *ts)
++{
++	if (!atomic_read(&ts->esd_timeout))
++		return;
++	cancel_delayed_work_sync(&ts->esd_work);
++}
++
++static int goodix_enable_esd(struct goodix_ts_data *ts)
++{
++	int error, esd_timeout;
++
++	esd_timeout = atomic_read(&ts->esd_timeout);
++	if (!esd_timeout)
++		return 0;
++
++	error = goodix_i2c_write_u8(ts->client, GOODIX_REG_ESD_CHECK,
++				    GOODIX_CMD_ESD_ENABLED);
++	if (error) {
++		dev_err(&ts->client->dev, "Failed to enable ESD: %d\n", error);
++		return error;
++	}
++
++	schedule_delayed_work(&ts->esd_work, round_jiffies_relative(
++			      msecs_to_jiffies(esd_timeout)));
++	return 0;
++}
++
++static void goodix_esd_work(struct work_struct *work)
++{
++	struct goodix_ts_data *ts = container_of(work, struct goodix_ts_data,
++						 esd_work.work);
++	int retries = 3, error;
++	u8 esd_data[2];
++	const struct firmware *cfg = NULL;
++
++	wait_for_completion(&ts->firmware_loading_complete);
++
++	while (--retries) {
++		error = goodix_i2c_read(ts->client, GOODIX_REG_COMMAND,
++					esd_data, sizeof(esd_data));
++		if (error)
++			continue;
++		if (esd_data[0] != GOODIX_CMD_ESD_ENABLED &&
++		    esd_data[1] == GOODIX_CMD_ESD_ENABLED) {
++			/* feed the watchdog */
++			goodix_i2c_write_u8(ts->client,
++					    GOODIX_REG_COMMAND,
++					    GOODIX_CMD_ESD_ENABLED);
++			break;
++		}
++	}
++
++	if (!retries) {
++		dev_dbg(&ts->client->dev, "Performing ESD recovery.\n");
++		goodix_free_irq(ts);
++		goodix_reset(ts);
++		error = request_firmware(&cfg, ts->cfg_name, &ts->client->dev);
++		if (!error) {
++			goodix_send_cfg(ts, cfg);
++			release_firmware(cfg);
++		}
++		goodix_request_irq(ts);
++		goodix_enable_esd(ts);
++		return;
++	}
++
++	schedule_delayed_work(&ts->esd_work, round_jiffies_relative(
++			      msecs_to_jiffies(atomic_read(&ts->esd_timeout))));
++}
++
++static ssize_t goodix_esd_timeout_show(struct device *dev,
++				       struct device_attribute *attr, char *buf)
++{
++	struct goodix_ts_data *ts = dev_get_drvdata(dev);
++
++	return scnprintf(buf, PAGE_SIZE, "%d\n", atomic_read(&ts->esd_timeout));
++}
++
++static ssize_t goodix_esd_timeout_store(struct device *dev,
++					struct device_attribute *attr,
++					const char *buf, size_t count)
++{
++	struct goodix_ts_data *ts = dev_get_drvdata(dev);
++	int error, esd_timeout, new_esd_timeout;
++
++	error = kstrtouint(buf, 10, &new_esd_timeout);
++	if (error)
++		return error;
++
++	esd_timeout = atomic_read(&ts->esd_timeout);
++	if (esd_timeout && !new_esd_timeout)
++		goodix_disable_esd(ts);
++
++	atomic_set(&ts->esd_timeout, new_esd_timeout);
++	if (!esd_timeout && new_esd_timeout)
++		goodix_enable_esd(ts);
++
++	return count;
++}
++
++/* ESD timeout in ms. Default disabled (0). Recommended 2000 ms. */
++static DEVICE_ATTR(esd_timeout, S_IRUGO | S_IWUSR, goodix_esd_timeout_show,
++		   goodix_esd_timeout_store);
++
++static struct attribute *goodix_attrs[] = {
++	&dev_attr_esd_timeout.attr,
++	NULL
++};
++
++static const struct attribute_group goodix_attr_group = {
++	.attrs = goodix_attrs,
++};
++
+ /**
+  * goodix_get_gpio_config - Get GPIO config from ACPI/DT
+  *
+@@ -709,7 +827,11 @@ static void goodix_config_cb(const struct firmware *cfg, void *ctx)
+ 			goto err_release_cfg;
+ 	}
+ 
+-	goodix_configure_dev(ts);
++	error = goodix_configure_dev(ts);
++	if (error)
++		goto err_release_cfg;
++
++	goodix_enable_esd(ts);
+ 
+ err_release_cfg:
+ 	release_firmware(cfg);
+@@ -720,7 +842,7 @@ static int goodix_ts_probe(struct i2c_client *client,
+ 			   const struct i2c_device_id *id)
+ {
+ 	struct goodix_ts_data *ts;
+-	int error;
++	int error, esd_timeout;
+ 
+ 	dev_dbg(&client->dev, "I2C Address: 0x%02x\n", client->addr);
+ 
+@@ -736,6 +858,7 @@ static int goodix_ts_probe(struct i2c_client *client,
+ 	ts->client = client;
+ 	i2c_set_clientdata(client, ts);
+ 	init_completion(&ts->firmware_loading_complete);
++	INIT_DELAYED_WORK(&ts->esd_work, goodix_esd_work);
+ 
+ 	error = goodix_get_gpio_config(ts);
+ 	if (error)
+@@ -765,11 +888,30 @@ static int goodix_ts_probe(struct i2c_client *client,
+ 	ts->cfg_len = goodix_get_cfg_len(ts->id);
+ 
+ 	if (ts->gpiod_int && ts->gpiod_rst) {
++
++		error = device_property_read_u32(&ts->client->dev,
++					GOODIX_DEVICE_ESD_TIMEOUT_PROPERTY,
++					&esd_timeout);
++		if (!error)
++			atomic_set(&ts->esd_timeout, esd_timeout);
++
++		error = sysfs_create_group(&client->dev.kobj,
++					   &goodix_attr_group);
++		if (error) {
++			dev_err(&client->dev,
++				"Failed to create sysfs group: %d\n",
++				error);
++			return error;
++		}
++
++
+ 		/* update device config */
+ 		ts->cfg_name = devm_kasprintf(&client->dev, GFP_KERNEL,
+ 					      "goodix_%d_cfg.bin", ts->id);
+-		if (!ts->cfg_name)
+-			return -ENOMEM;
++		if (!ts->cfg_name) {
++			error = -ENOMEM;
++			goto err_sysfs_remove_group;
++		}
+ 
+ 		error = request_firmware_nowait(THIS_MODULE, true, ts->cfg_name,
+ 						&client->dev, GFP_KERNEL, ts,
+@@ -788,6 +930,10 @@ static int goodix_ts_probe(struct i2c_client *client,
+ 			return error;
+ 	}
+ 
++err_sysfs_remove_group:
++	if (ts->gpiod_int && ts->gpiod_rst)
++		sysfs_remove_group(&client->dev.kobj, &goodix_attr_group);
++
+ 	return 0;
+ }
+ 
+@@ -795,8 +941,11 @@ static int goodix_ts_remove(struct i2c_client *client)
+ {
+ 	struct goodix_ts_data *ts = i2c_get_clientdata(client);
+ 
+-	if (ts->gpiod_int && ts->gpiod_rst)
++	if (ts->gpiod_int && ts->gpiod_rst) {
+ 		wait_for_completion(&ts->firmware_loading_complete);
++		sysfs_remove_group(&client->dev.kobj, &goodix_attr_group);
++		goodix_disable_esd(ts);
++	}
+ 
+ 	return 0;
+ }
+@@ -814,6 +963,7 @@ static int __maybe_unused goodix_suspend(struct device *dev)
+ 	}
+ 
+ 	wait_for_completion(&ts->firmware_loading_complete);
++	goodix_disable_esd(ts);
+ 
+ 	/* Free IRQ as IRQ pin is used as output in the suspend sequence */
+ 	goodix_free_irq(ts);
+@@ -874,6 +1024,8 @@ static int __maybe_unused goodix_resume(struct device *dev)
+ 	if (error)
+ 		return error;
+ 
++	return goodix_enable_esd(ts);
++
+ 	return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0022-Add-RST-touchpanel-pin-GPIO4_IO24.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0022-Add-RST-touchpanel-pin-GPIO4_IO24.patch
@@ -1,0 +1,39 @@
+From f8ca7a448290ec6175cbdd056e822dc10db45dcf Mon Sep 17 00:00:00 2001
+From: Vicentiu Galanopulo <vicentiu@balena.io>
+Date: Mon, 29 Mar 2021 12:02:15 +0200
+Subject: [PATCH] Add RST touchpanel pin GPIO4_IO24
+
+The RST pin is needed to do a hardware reset of the
+touchpanel
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ arch/arm64/boot/dts/compulab/cl-som-imx8.dts | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+index 64db40cb540f..08cfb2ca572a 100644
+--- a/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
++++ b/arch/arm64/boot/dts/compulab/cl-som-imx8.dts
+@@ -60,7 +60,9 @@
+ 			fsl,pins = <
+ 				#define GPIRQ_GT911		<&gpio4 26 IRQ_TYPE_LEVEL_HIGH>
+ 				#define GP_GT911_IRQ		<&gpio4 26 GPIO_ACTIVE_HIGH>
++				#define GP_GT911_RESET          <&gpio4 24 GPIO_ACTIVE_LOW>
+ 				MX8MQ_IOMUXC_SAI2_TXD0_GPIO4_IO26	0x1D6
++				MX8MQ_IOMUXC_SAI2_TXFS_GPIO4_IO24	0x176
+ 			>;
+ 		};
+ 	};
+@@ -430,6 +432,7 @@
+ 		esd-recovery-timeout-ms = <2000>;
+ 		interrupts-extended = GPIRQ_GT911;
+ 		irq-gpios = GP_GT911_IRQ;
++		reset-gpios = GP_GT911_RESET;
+ 		status = "okay";
+ 	};
+ 
+-- 
+2.17.1
+

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -37,6 +37,8 @@ SRC_URI_append_etcher-pro = " \
 	file://0018-Enable-UART1-node.patch \
 	file://0019-Add-kernel-5.x-mainline-KSZ9893-switch-support.patch \
 	file://0020-Disable-internal-imx-RTC-and-external-i2c-RTC.patch \
+	file://0021-Input-goodix-add-support-for-ESD.patch \
+	file://0022-Add-RST-touchpanel-pin-GPIO4_IO24.patch \
 	file://sbc-imx8-no-wp_v2.46.0+rev10.dtb \
 	file://sbc-imx8-no-wp_v2.51.1+rev3.dtb \
 "


### PR DESCRIPTION
Add ESD (Electrostatic Discharge) protection mechanism.

The driver enables ESD protection in HW and checks a register
to determine if ESD occurred. If ESD is signalled by the HW,
the driver will reset the device.

The ESD poll time (in ms) can be set through
esd-recovery-timeout-ms ACPI/DT property. If it is set to 0,
ESD protection is disabled.

Changelog-entry: Add touchpanel ESD support
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>