### PR TITLE
Fix support for Maxen display using a modified Raydium RM67191 driver

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-drm-panel-raydium-rm67191-Adjust-for-Maxen-display.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-drm-panel-raydium-rm67191-Adjust-for-Maxen-display.patch
@@ -1,0 +1,522 @@
+From 28316638f6613efbbb34e390aac24b49b6903312 Mon Sep 17 00:00:00 2001
+From: Alex Gonzalez <alexg@balena.io>
+Date: Fri, 25 Jun 2021 21:54:58 +0200
+Subject: [PATCH] drm: panel-raydium-rm67191: Adjust for Maxen display
+
+The Maxen display has a driver IC EK79007AD & EK73215BCGA, not really an
+RM67191. Even so, we are using this driver and patching it only for the
+Etcher Pro platform that uses this display.
+
+This commit:
+
+* Removes Raydium specific settings
+* Refactors prepare/unprepare and enable/disable to match panel-simple
+* Always uses low power mode for transactions - this avoids DSI timeout problems when switching modes
+* Uses non-burst sync pulses events
+* Rationalises reset pin logic
+* Introduces small delays to guarantee DSI bus setup before use
+* Set display timings to the typical timings from the vendor's datasheet:
+
+HSD period: 1344
+VSD Period: 635
+HSD Back Porch: 160
+HSD Front Porch: 16 - 160 - 216
+VSD Back Porch: 23
+VSD Front Porch: 1 - 12 - 127
+
+Change-type: patch
+Upstream-status: Inappropriate (embedded platform specific)
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ drivers/gpu/drm/panel/panel-raydium-rm67191.c | 380 +++---------------
+ 1 file changed, 59 insertions(+), 321 deletions(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-raydium-rm67191.c b/drivers/gpu/drm/panel/panel-raydium-rm67191.c
+index 594b6d0d5b28..2cc68de5d45f 100644
+--- a/drivers/gpu/drm/panel/panel-raydium-rm67191.c
++++ b/drivers/gpu/drm/panel/panel-raydium-rm67191.c
+@@ -26,165 +26,6 @@
+ #include <video/of_videomode.h>
+ #include <video/videomode.h>
+ 
+-/* Write Manufacture Command Set Control */
+-#define WRMAUCCTR 0xFE
+-
+-/* Manufacturer Command Set pages (CMD2) */
+-struct cmd_set_entry {
+-	u8 cmd;
+-	u8 param;
+-};
+-
+-/*
+- * There is no description in the Reference Manual about these commands.
+- * We received them from vendor, so just use them as is.
+- */
+-static const struct cmd_set_entry manufacturer_cmd_set[] = {
+-	{0xFE, 0x0B},
+-	{0x28, 0x40},
+-	{0x29, 0x4F},
+-	{0xFE, 0x0E},
+-	{0x4B, 0x00},
+-	{0x4C, 0x0F},
+-	{0x4D, 0x20},
+-	{0x4E, 0x40},
+-	{0x4F, 0x60},
+-	{0x50, 0xA0},
+-	{0x51, 0xC0},
+-	{0x52, 0xE0},
+-	{0x53, 0xFF},
+-	{0xFE, 0x0D},
+-	{0x18, 0x08},
+-	{0x42, 0x00},
+-	{0x08, 0x41},
+-	{0x46, 0x02},
+-	{0x72, 0x09},
+-	{0xFE, 0x0A},
+-	{0x24, 0x17},
+-	{0x04, 0x07},
+-	{0x1A, 0x0C},
+-	{0x0F, 0x44},
+-	{0xFE, 0x04},
+-	{0x00, 0x0C},
+-	{0x05, 0x08},
+-	{0x06, 0x08},
+-	{0x08, 0x08},
+-	{0x09, 0x08},
+-	{0x0A, 0xE6},
+-	{0x0B, 0x8C},
+-	{0x1A, 0x12},
+-	{0x1E, 0xE0},
+-	{0x29, 0x93},
+-	{0x2A, 0x93},
+-	{0x2F, 0x02},
+-	{0x31, 0x02},
+-	{0x33, 0x05},
+-	{0x37, 0x2D},
+-	{0x38, 0x2D},
+-	{0x3A, 0x1E},
+-	{0x3B, 0x1E},
+-	{0x3D, 0x27},
+-	{0x3F, 0x80},
+-	{0x40, 0x40},
+-	{0x41, 0xE0},
+-	{0x4F, 0x2F},
+-	{0x50, 0x1E},
+-	{0xFE, 0x06},
+-	{0x00, 0xCC},
+-	{0x05, 0x05},
+-	{0x07, 0xA2},
+-	{0x08, 0xCC},
+-	{0x0D, 0x03},
+-	{0x0F, 0xA2},
+-	{0x32, 0xCC},
+-	{0x37, 0x05},
+-	{0x39, 0x83},
+-	{0x3A, 0xCC},
+-	{0x41, 0x04},
+-	{0x43, 0x83},
+-	{0x44, 0xCC},
+-	{0x49, 0x05},
+-	{0x4B, 0xA2},
+-	{0x4C, 0xCC},
+-	{0x51, 0x03},
+-	{0x53, 0xA2},
+-	{0x75, 0xCC},
+-	{0x7A, 0x03},
+-	{0x7C, 0x83},
+-	{0x7D, 0xCC},
+-	{0x82, 0x02},
+-	{0x84, 0x83},
+-	{0x85, 0xEC},
+-	{0x86, 0x0F},
+-	{0x87, 0xFF},
+-	{0x88, 0x00},
+-	{0x8A, 0x02},
+-	{0x8C, 0xA2},
+-	{0x8D, 0xEA},
+-	{0x8E, 0x01},
+-	{0x8F, 0xE8},
+-	{0xFE, 0x06},
+-	{0x90, 0x0A},
+-	{0x92, 0x06},
+-	{0x93, 0xA0},
+-	{0x94, 0xA8},
+-	{0x95, 0xEC},
+-	{0x96, 0x0F},
+-	{0x97, 0xFF},
+-	{0x98, 0x00},
+-	{0x9A, 0x02},
+-	{0x9C, 0xA2},
+-	{0xAC, 0x04},
+-	{0xFE, 0x06},
+-	{0xB1, 0x12},
+-	{0xB2, 0x17},
+-	{0xB3, 0x17},
+-	{0xB4, 0x17},
+-	{0xB5, 0x17},
+-	{0xB6, 0x11},
+-	{0xB7, 0x08},
+-	{0xB8, 0x09},
+-	{0xB9, 0x06},
+-	{0xBA, 0x07},
+-	{0xBB, 0x17},
+-	{0xBC, 0x17},
+-	{0xBD, 0x17},
+-	{0xBE, 0x17},
+-	{0xBF, 0x17},
+-	{0xC0, 0x17},
+-	{0xC1, 0x17},
+-	{0xC2, 0x17},
+-	{0xC3, 0x17},
+-	{0xC4, 0x0F},
+-	{0xC5, 0x0E},
+-	{0xC6, 0x00},
+-	{0xC7, 0x01},
+-	{0xC8, 0x10},
+-	{0xFE, 0x06},
+-	{0x95, 0xEC},
+-	{0x8D, 0xEE},
+-	{0x44, 0xEC},
+-	{0x4C, 0xEC},
+-	{0x32, 0xEC},
+-	{0x3A, 0xEC},
+-	{0x7D, 0xEC},
+-	{0x75, 0xEC},
+-	{0x00, 0xEC},
+-	{0x08, 0xEC},
+-	{0x85, 0xEC},
+-	{0xA6, 0x21},
+-	{0xA7, 0x05},
+-	{0xA9, 0x06},
+-	{0x82, 0x06},
+-	{0x41, 0x06},
+-	{0x7A, 0x07},
+-	{0x37, 0x07},
+-	{0x05, 0x06},
+-	{0x49, 0x06},
+-	{0x0D, 0x04},
+-	{0x51, 0x04},
+-};
+-
+ static const u32 rad_bus_formats[] = {
+ 	MEDIA_BUS_FMT_RGB888_1X24,
+ 	MEDIA_BUS_FMT_RGB666_1X18,
+@@ -211,42 +52,12 @@ static inline struct rad_panel *to_rad_panel(struct drm_panel *panel)
+ 	return container_of(panel, struct rad_panel, base);
+ }
+ 
+-static int rad_panel_push_cmd_list(struct mipi_dsi_device *dsi)
+-{
+-	size_t i;
+-	size_t count = ARRAY_SIZE(manufacturer_cmd_set);
+-	int ret = 0;
+-
+-	for (i = 0; i < count; i++) {
+-		const struct cmd_set_entry *entry = &manufacturer_cmd_set[i];
+-		u8 buffer[2] = { entry->cmd, entry->param };
+-
+-		ret = mipi_dsi_generic_write(dsi, &buffer, sizeof(buffer));
+-		if (ret < 0)
+-			return ret;
+-	}
+-
+-	return ret;
+-};
+-
+-static int color_format_from_dsi_format(enum mipi_dsi_pixel_format format)
+-{
+-	switch (format) {
+-	case MIPI_DSI_FMT_RGB565:
+-		return 0x55;
+-	case MIPI_DSI_FMT_RGB666:
+-	case MIPI_DSI_FMT_RGB666_PACKED:
+-		return 0x66;
+-	case MIPI_DSI_FMT_RGB888:
+-		return 0x77;
+-	default:
+-		return 0x77; /* for backward compatibility */
+-	}
+-};
+-
+ static int rad_panel_prepare(struct drm_panel *panel)
+ {
+ 	struct rad_panel *rad = to_rad_panel(panel);
++	struct mipi_dsi_device *dsi = rad->dsi;
++	struct device *dev = &dsi->dev;
++	int ret;
+ 
+ 	if (rad->prepared)
+ 		return 0;
+@@ -258,109 +69,8 @@ static int rad_panel_prepare(struct drm_panel *panel)
+ 		usleep_range(20000, 25000);
+ 	}
+ 
+-	rad->prepared = true;
+-
+-	return 0;
+-}
+-
+-static int rad_panel_unprepare(struct drm_panel *panel)
+-{
+-	struct rad_panel *rad = to_rad_panel(panel);
+-	struct device *dev = &rad->dsi->dev;
+-
+-	if (!rad->prepared)
+-		return 0;
+-
+-	if (rad->enabled) {
+-		DRM_DEV_ERROR(dev, "Panel still enabled!\n");
+-		return -EPERM;
+-	}
+-
+-	if (rad->reset != NULL) {
+-		gpiod_set_value(rad->reset, 0);
+-		usleep_range(15000, 17000);
+-		gpiod_set_value(rad->reset, 1);
+-	}
+-
+-	rad->prepared = false;
+-
+-	return 0;
+-}
+-
+-static int rad_panel_enable(struct drm_panel *panel)
+-{
+-	struct rad_panel *rad = to_rad_panel(panel);
+-	struct mipi_dsi_device *dsi = rad->dsi;
+-	struct device *dev = &dsi->dev;
+-	int color_format = color_format_from_dsi_format(dsi->format);
+-	u16 brightness;
+-	int ret;
+-
+-	if (rad->enabled)
+-		return 0;
+-
+-	if (!rad->prepared) {
+-		DRM_DEV_ERROR(dev, "Panel not prepared!\n");
+-		return -EPERM;
+-	}
+-
+ 	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+ 
+-	ret = rad_panel_push_cmd_list(dsi);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to send MCS (%d)\n", ret);
+-		goto fail;
+-	}
+-
+-	/* Select User Command Set table (CMD1) */
+-	ret = mipi_dsi_generic_write(dsi, (u8[]){ WRMAUCCTR, 0x00 }, 2);
+-	if (ret < 0)
+-		goto fail;
+-
+-	/* Software reset */
+-	ret = mipi_dsi_dcs_soft_reset(dsi);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to do Software Reset (%d)\n", ret);
+-		goto fail;
+-	}
+-
+-	usleep_range(15000, 17000);
+-
+-	/* Set DSI mode */
+-	ret = mipi_dsi_generic_write(dsi, (u8[]){ 0xC2, 0x0B }, 2);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to set DSI mode (%d)\n", ret);
+-		goto fail;
+-	}
+-	/* Set tear ON */
+-	ret = mipi_dsi_dcs_set_tear_on(dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to set tear ON (%d)\n", ret);
+-		goto fail;
+-	}
+-	/* Set tear scanline */
+-	ret = mipi_dsi_dcs_set_tear_scanline(dsi, 0x380);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to set tear scanline (%d)\n", ret);
+-		goto fail;
+-	}
+-	/* Set pixel format */
+-	ret = mipi_dsi_dcs_set_pixel_format(dsi, color_format);
+-	DRM_DEV_DEBUG_DRIVER(dev, "Interface color format set to 0x%x\n",
+-				color_format);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to set pixel format (%d)\n", ret);
+-		goto fail;
+-	}
+-	/* Set display brightness */
+-	brightness = rad->backlight->props.brightness;
+-	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+-	if (ret < 0) {
+-		DRM_DEV_ERROR(dev, "Failed to set display brightness (%d)\n",
+-			      ret);
+-		goto fail;
+-	}
+-	/* Exit sleep mode */
+ 	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+ 	if (ret < 0) {
+ 		DRM_DEV_ERROR(dev, "Failed to exit sleep mode (%d)\n", ret);
+@@ -375,9 +85,7 @@ static int rad_panel_enable(struct drm_panel *panel)
+ 		goto fail;
+ 	}
+ 
+-	backlight_enable(rad->backlight);
+-
+-	rad->enabled = true;
++	rad->prepared = true;
+ 
+ 	return 0;
+ 
+@@ -388,21 +96,23 @@ static int rad_panel_enable(struct drm_panel *panel)
+ 	return ret;
+ }
+ 
+-static int rad_panel_disable(struct drm_panel *panel)
++static int rad_panel_unprepare(struct drm_panel *panel)
+ {
+ 	struct rad_panel *rad = to_rad_panel(panel);
+ 	struct mipi_dsi_device *dsi = rad->dsi;
+ 	struct device *dev = &dsi->dev;
+ 	int ret;
+ 
+-	if (!rad->enabled)
++	if (!rad->prepared)
+ 		return 0;
+ 
+-	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+-
+-	backlight_disable(rad->backlight);
++	if (rad->reset != NULL) {
++		gpiod_set_value(rad->reset, 0);
++		usleep_range(15000, 17000);
++		gpiod_set_value(rad->reset, 1);
++	}
+ 
+-	usleep_range(10000, 15000);
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+ 
+ 	ret = mipi_dsi_dcs_set_display_off(dsi);
+ 	if (ret < 0) {
+@@ -418,6 +128,34 @@ static int rad_panel_disable(struct drm_panel *panel)
+ 		return ret;
+ 	}
+ 
++	rad->prepared = false;
++
++	return 0;
++}
++
++static int rad_panel_enable(struct drm_panel *panel)
++{
++	struct rad_panel *rad = to_rad_panel(panel);
++
++	if (rad->enabled)
++		return 0;
++
++	backlight_enable(rad->backlight);
++
++	rad->enabled = true;
++
++	return 0;
++}
++
++static int rad_panel_disable(struct drm_panel *panel)
++{
++	struct rad_panel *rad = to_rad_panel(panel);
++
++	if (!rad->enabled)
++		return 0;
++
++	backlight_disable(rad->backlight);
++
+ 	rad->enabled = false;
+ 
+ 	return 0;
+@@ -461,6 +199,7 @@ static int rad_panel_get_modes(struct drm_panel *panel)
+ 
+ 	drm_mode_probed_add(panel->connector, mode);
+ 
++	msleep(70);
+ 	return 1;
+ }
+ 
+@@ -477,7 +216,7 @@ static int rad_bl_get_brightness(struct backlight_device *bl)
+ 
+ 	DRM_DEV_DEBUG_DRIVER(dev, "\n");
+ 
+-	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+ 
+ 	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
+ 	if (ret < 0)
+@@ -500,7 +239,9 @@ static int rad_bl_update_status(struct backlight_device *bl)
+ 
+ 	DRM_DEV_DEBUG_DRIVER(dev, "New brightness: %d\n", bl->props.brightness);
+ 
+-	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
++	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
++
++	msleep(20);
+ 
+ 	ret = mipi_dsi_dcs_set_display_brightness(dsi, bl->props.brightness);
+ 	if (ret < 0)
+@@ -509,21 +250,16 @@ static int rad_bl_update_status(struct backlight_device *bl)
+ 	return 0;
+ }
+ 
+-static int rad_panel_dummy(struct drm_panel *panel)
+-{
+-	return 0;
+-}
+-
+ static const struct backlight_ops rad_bl_ops = {
+ 	.update_status = rad_bl_update_status,
+ 	.get_brightness = rad_bl_get_brightness,
+ };
+ 
+ static const struct drm_panel_funcs rad_panel_funcs = {
+-	.prepare = rad_panel_dummy,
+-	.unprepare = rad_panel_dummy,
+-	.enable = rad_panel_dummy,
+-	.disable = rad_panel_dummy,
++	.prepare = rad_panel_prepare,
++	.unprepare = rad_panel_unprepare,
++	.enable = rad_panel_enable,
++	.disable = rad_panel_disable,
+ 	.get_modes = rad_panel_get_modes,
+ };
+ 
+@@ -534,13 +270,13 @@ static const struct drm_panel_funcs rad_panel_funcs = {
+ static const struct display_timing rad_default_timing = {
+ 	.pixelclock = { 52000000, 52000000, 52000000 },
+ 	.hactive = {  1024, 1024, 1024 },
+-	.hfront_porch = { 300, 300, 300 },
+-	.hsync_len = { 10, 10 , 10},
+-	.hback_porch = { 10, 10, 10 },
++	.hfront_porch = { 160, 160, 160 },
++	.hsync_len = { 1, 1, 1},
++	.hback_porch = { 160, 160, 160 },
+ 	.vactive = { 600, 600, 600 },
+-	.vfront_porch = { 10, 10, 10 },
+-	.vsync_len = { 10, 10, 10 },
+-	.vback_porch = { 15, 15, 15 },
++	.vfront_porch = { 12, 12, 12 },
++	.vsync_len = { 1, 1, 1 },
++	.vback_porch = { 23, 23, 23 },
+ 	.flags = DISPLAY_FLAGS_HSYNC_LOW |
+ 		 DISPLAY_FLAGS_VSYNC_LOW |
+ 		 DISPLAY_FLAGS_DE_LOW |
+@@ -566,8 +302,10 @@ static int rad_panel_probe(struct mipi_dsi_device *dsi)
+ 	panel->dsi = dsi;
+ 
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+-	dsi->mode_flags =  MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_VIDEO |
+-			   MIPI_DSI_CLOCK_NON_CONTINUOUS;
++	dsi->mode_flags =  MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
++			   MIPI_DSI_MODE_VIDEO_HSE |
++			   MIPI_DSI_CLOCK_NON_CONTINUOUS |
++			   MIPI_DSI_MODE_VIDEO;
+ 
+ 	ret = of_property_read_u32(np, "video-mode", &video_mode);
+ 	if (!ret) {

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0002-nwl_dsi-imx-Delays-before-and-after-clock-enabling-d.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0002-nwl_dsi-imx-Delays-before-and-after-clock-enabling-d.patch
@@ -1,0 +1,46 @@
+From cc4b44179a793eb5b6764d42fba770bfae233138 Mon Sep 17 00:00:00 2001
+From: Alex Gonzalez <alexg@balena.io>
+Date: Fri, 2 Jul 2021 20:11:11 +0200
+Subject: [PATCH] nwl_dsi-imx: Delays before and after clock
+ enabling/disabling.
+
+Introduce delays before clock setups to guarantee parent PLLs clock
+stability and after clock setup to gurantee the clocks are stable before
+being used.
+
+Change-type: patch
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ drivers/gpu/drm/imx/nwl_dsi-imx.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/imx/nwl_dsi-imx.c b/drivers/gpu/drm/imx/nwl_dsi-imx.c
+index 658619936745..07f16594e8a1 100644
+--- a/drivers/gpu/drm/imx/nwl_dsi-imx.c
++++ b/drivers/gpu/drm/imx/nwl_dsi-imx.c
+@@ -502,8 +502,12 @@ static void imx_nwl_dsi_enable(struct imx_mipi_dsi *dsi)
+ 
+ 	request_bus_freq(BUS_FREQ_HIGH);
+ 
++	msleep(100);
++
+ 	imx_nwl_dsi_set_clocks(dsi, true);
+ 
++	msleep(20);
++
+ 	ret = devtype->poweron(dsi);
+ 	if (ret < 0) {
+ 		DRM_DEV_ERROR(dev, "Failed to power on DSI (%d)\n", ret);
+@@ -528,8 +532,12 @@ static void imx_nwl_dsi_disable(struct imx_mipi_dsi *dsi)
+ 	if (!dsi->no_clk_reset)
+ 		devtype->poweroff(dsi);
+ 
++	msleep(10);
++
+ 	imx_nwl_dsi_set_clocks(dsi, false);
+ 
++	msleep(8);
++
+ 	release_bus_freq(BUS_FREQ_HIGH);
+ 
+ 	dsi->enabled = false;

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -42,6 +42,8 @@ SRC_URI_append_etcher-pro = " \
 	file://0023-Add-dts-thermal-PWM-cooling.patch \
 	file://sbc-imx8-no-wp_v2.46.0+rev10.dtb \
 	file://sbc-imx8-no-wp_v2.51.1+rev3.dtb \
+	file://0001-drm-panel-raydium-rm67191-Adjust-for-Maxen-display.patch \
+	file://0002-nwl_dsi-imx-Delays-before-and-after-clock-enabling-d.patch \
 "
 
 KERNEL_IMAGETYPE_cl-som-imx8 = "Image.gz"


### PR DESCRIPTION
This PR sets the manufacturer's default timings and modifies the driver to initialize the display.
