### PR TITLE
resin-init: add missing quotes to resin-init-board

### DIFF
--- a/layers/meta-balena-compulab/recipes-support/resin-init/resin-init-board/resin-init-board
+++ b/layers/meta-balena-compulab/recipes-support/resin-init/resin-init-board/resin-init-board
@@ -4,7 +4,7 @@ set -e
 
 EP_VERSION=$(sed -n "s/^.*ep_version=\s*\(\S*\).*$/\1/p" /proc/cmdline)
 
-if [ $EP_VERSION = "02460010" ]; then
+if [ "$EP_VERSION" = "02460010" ]; then
     echo "PWM backlight control for the MIPI display not available in this EP hw version"
     exit 0
 fi


### PR DESCRIPTION
The resin-init-board script fails to run due to missing quotes in the conditional test. This causes the following error to be reported at boot time:
```
Sep 14 11:44:24 localhost bash[1108]: /usr/bin/resin-init-board: line 7: [: =: unary operator expected
```

Change-type: patch
Changelog-entry: resin-init: add missing quotes to resin-init-board
Signed-off-by: Mark Corbin <mark@balena.io>