### PR TITLE
balena-init: copy resin-init into balena-init

### DIFF
--- a/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-board.bbappend
+++ b/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-board.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
+SRC_URI = "file://balena-init-board"
+S = "${WORKDIR}"
+
+RDEPENDS_${PN} = "bash"
+
+do_install_append_etcher-pro() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/balena-init-board ${D}${bindir}
+}

--- a/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-board/balena-init-board
+++ b/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-board/balena-init-board
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+EP_VERSION=$(sed -n "s/^.*ep_version=\s*\(\S*\).*$/\1/p" /proc/cmdline)
+
+if [ "$EP_VERSION" = "02460010" ]; then
+    echo "PWM backlight control for the MIPI display not available in this EP hw version"
+    exit 0
+fi
+
+if [ -d /sys/class/pwm/pwmchip2 ]
+then
+  echo 0 > /sys/class/pwm/pwmchip2/export
+  # Short delay
+  sleep 1;
+
+  if [ -d /sys/class/pwm/pwmchip2/pwm0 ]
+  then
+    echo 45000 > /sys/class/pwm/pwmchip2/pwm0/period
+    echo 20000 > /sys/class/pwm/pwmchip2/pwm0/duty_cycle
+    echo 1 > /sys/class/pwm/pwmchip2/pwm0/enable
+  fi
+fi
+
+exit 0
+

--- a/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-flasher.bbappend
+++ b/layers/meta-balena-compulab/recipes-support/balena-init/balena-init-flasher.bbappend
@@ -1,0 +1,1 @@
+INTERNAL_DEVICE_KERNEL_cl-som-imx8 = "mmcblk0"


### PR DESCRIPTION
New meta-balena versions have renamed this recipe. Keeping both will allow to update to the new meta-balena versions, and resin-init can be removed after the update.

Changelog-entry: copy resin-init into balena-init
Signed-off-by: Alex Gonzalez <alexg@balena.io>