### PR TITLE
update meta-fsl-bsp URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/compulab-yokneam/meta-bsp-imx8mq.git
 [submodule "layers/meta-fsl-bsp-release"]
         path = layers/meta-fsl-bsp-release
-        url = https://source.codeaurora.org/external/imx/meta-fsl-bsp-release
+        url = https://git.codelinaro.org/clo/imx-support/meta-fsl-bsp-release.git
 [submodule "layers/meta-openembedded"]
 	path = layers/meta-openembedded
 	url = https://github.com/openembedded/meta-openembedded.git


### PR DESCRIPTION
codeaurora repo that was hosting meta-fsl-bsp shut down as of 21/03/23  https://bye.codeaurora.org/

the bsp was moved to https://git.codelinaro.org/clo/imx-support/meta-fsl-bsp-release/-/tree/fc3130ecfce72ff6d3013f5fa464ed2a72af8b00 instead - updated the URL to match

Change-type: patch