### PR TITLE
Use older MM, libmbim and libqmi

### DIFF
--- a/layers/meta-balena-compulab/conf/layer.conf
+++ b/layers/meta-balena-compulab/conf/layer.conf
@@ -17,3 +17,11 @@ BBMASK += "imx/meta-bsp/recipes-bsp/imx-atf/imx-atf_2.0.bb"
 BBMASK += "imx/meta-bsp/recipes-bsp/imx-mkimage/*"
 
 SERIAL_CONSOLES_cl-som-imx8 = "115200;ttymxc2"
+
+# These versions are used because the ModemManager
+# update in meta-balena cannot be built with
+# Meson older than 0.53.0. See internal
+# discussion https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/Compulab.20IOT-gate-imx8/near/374666230
+PREFERRED_VERSION_libmbim = "1.26.2"
+PREFERRED_VERSION_libqmi = "1.30.2"
+PREFERRED_VERSION_modemmanager = "1.18.4"

--- a/layers/meta-balena-compulab/recipes-connectivity/libmbim/libmbim/clang.patch
+++ b/layers/meta-balena-compulab/recipes-connectivity/libmbim/libmbim/clang.patch
@@ -1,0 +1,82 @@
+From a5a83490a162ebadee06814338215e001197a70b Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 1 Sep 2017 17:01:15 +0100
+Subject: [PATCH] libqmi: Update to 1.16.0
+
+Check for clang compiler since we need to disable
+unused-function warning for clang, at same time
+pass werror when checking for compiler options if
+werror is enabled so spurious options do not get
+enabled. Only the ones that are supported by given
+compiler are accepted.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+
+---
+ m4/compiler-warnings.m4 | 29 +++++++++++++++++++++++++----
+ 1 file changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/m4/compiler-warnings.m4 b/m4/compiler-warnings.m4
+index 77b79c5..b132a29 100644
+--- a/m4/compiler-warnings.m4
++++ b/m4/compiler-warnings.m4
+@@ -2,10 +2,30 @@ AC_DEFUN([LIBMBIM_COMPILER_WARNINGS],
+ [AC_ARG_ENABLE(more-warnings,
+ 	AS_HELP_STRING([--enable-more-warnings], [Possible values: no/yes/error]),
+ 	set_more_warnings="$enableval",set_more_warnings=error)
++
++# Clang throws a lot of warnings when it does not understand a flag. Disable
++# this warning for now so other warnings are visible.
++AC_MSG_CHECKING([if compiling with clang])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
++#ifndef __clang__
++	not clang
++#endif
++	]])],
++	[CLANG=yes],
++	[CLANG=no]
++)
++AC_MSG_RESULT([$CLANG])
++AS_IF([test "x$CLANG" = "xyes"], [CLANG_FLAGS=-Wno-error=unused-function])
++CFLAGS="$CFLAGS $CLANG_FLAGS"
++LDFLAGS="$LDFLAGS $CLANG_FLAGS"
++
+ AC_MSG_CHECKING(for more warnings)
+ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
+ 	AC_MSG_RESULT(yes)
+ 	CFLAGS="-Wall -std=gnu89 $CFLAGS"
++	if test "x$set_more_warnings" = xerror; then
++		WERROR="-Werror"
++	fi
+ 
+ 	for option in -Wmissing-declarations -Wmissing-prototypes \
+ 		      -Wdeclaration-after-statement -Wstrict-prototypes \
+@@ -17,22 +37,23 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
+ 		      -Wmissing-include-dirs -Waggregate-return \
+ 		      -Wformat-security -Wtype-limits; do
+ 		SAVE_CFLAGS="$CFLAGS"
+-		CFLAGS="$CFLAGS $option"
++		CFLAGS="$CFLAGS $option $WERROR"
+ 		AC_MSG_CHECKING([whether gcc understands $option])
+ 		AC_TRY_COMPILE([], [],
+ 			has_option=yes,
+ 			has_option=no,)
+ 		if test $has_option = no; then
+ 			CFLAGS="$SAVE_CFLAGS"
++		else
++			CFLAGS="$SAVE_CFLAGS $option"
+ 		fi
+ 		AC_MSG_RESULT($has_option)
+ 		unset has_option
+ 		unset SAVE_CFLAGS
+ 	done
++	CFLAGS="$CFLAGS $WERROR"
+ 	unset option
+-	if test "x$set_more_warnings" = xerror; then
+-		CFLAGS="$CFLAGS -Werror"
+-	fi
++	unset WERROR
+ else
+ 	AC_MSG_RESULT(no)
+ fi

--- a/layers/meta-balena-compulab/recipes-connectivity/libmbim/libmbim_1.26.2.bb
+++ b/layers/meta-balena-compulab/recipes-connectivity/libmbim/libmbim_1.26.2.bb
@@ -1,0 +1,16 @@
+SUMMARY = "libmbim is library for talking to WWAN devices by MBIM protocol"
+DESCRIPTION = "libmbim is a glib-based library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libmbim/"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libgudev autoconf-archive"
+
+inherit autotools pkgconfig bash-completion gobject-introspection
+
+SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "10c77bf5b5eb8c92ba80e9b519923ad9b898362bc8e1928e2bc9a17eeba649af"

--- a/layers/meta-balena-compulab/recipes-connectivity/libqmi/libqmi/0001-Detect-clang.patch
+++ b/layers/meta-balena-compulab/recipes-connectivity/libqmi/libqmi/0001-Detect-clang.patch
@@ -1,0 +1,85 @@
+From 4cfb728804157e8f3c69e11ba4df449d8f76388f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 20 Oct 2016 04:42:26 +0000
+Subject: [PATCH] Detect clang
+
+Check for clang compiler since we need to disable
+unused-function warning for clang, at same time
+pass werror when checking for compiler options if
+werror is enabled so spurious options do not get
+enabled. Only the ones that are supported by given
+compiler are accepted.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+
+---
+ m4/compiler-warnings.m4 | 29 +++++++++++++++++++++++++----
+ 1 file changed, 25 insertions(+), 4 deletions(-)
+
+diff --git a/m4/compiler-warnings.m4 b/m4/compiler-warnings.m4
+index de4a8b0..e4ba718 100644
+--- a/m4/compiler-warnings.m4
++++ b/m4/compiler-warnings.m4
+@@ -2,10 +2,30 @@ AC_DEFUN([LIBQMI_COMPILER_WARNINGS],
+ [AC_ARG_ENABLE(more-warnings,
+ 	AS_HELP_STRING([--enable-more-warnings], [Possible values: no/yes/error]),
+ 	set_more_warnings="$enableval",set_more_warnings=error)
++
++# Clang throws a lot of warnings when it does not understand a flag. Disable
++# this warning for now so other warnings are visible.
++AC_MSG_CHECKING([if compiling with clang])
++AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
++#ifndef __clang__
++	not clang
++#endif
++	]])],
++	[CLANG=yes],
++	[CLANG=no]
++)
++AC_MSG_RESULT([$CLANG])
++AS_IF([test "x$CLANG" = "xyes"], [CLANG_FLAGS=-Wno-error=unused-function])
++CFLAGS="$CFLAGS $CLANG_FLAGS"
++LDFLAGS="$LDFLAGS $CLANG_FLAGS"
++
+ AC_MSG_CHECKING(for more warnings)
+ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
+ 	AC_MSG_RESULT(yes)
+ 	CFLAGS="-Wall -std=gnu89 $CFLAGS"
++	if test "x$set_more_warnings" = xerror; then
++		WERROR="-Werror"
++	fi
+ 
+ 	for option in -Wmissing-declarations -Wmissing-prototypes \
+ 		      -Wdeclaration-after-statement -Wstrict-prototypes \
+@@ -17,22 +37,23 @@ if test "$GCC" = "yes" -a "$set_more_warnings" != "no"; then
+ 		      -Wmissing-include-dirs -Waggregate-return \
+ 		      -Wformat-security -Wtype-limits; do
+ 		SAVE_CFLAGS="$CFLAGS"
+-		CFLAGS="$CFLAGS $option"
++		CFLAGS="$CFLAGS $option $WERROR"
+ 		AC_MSG_CHECKING([whether gcc understands $option])
+ 		AC_TRY_COMPILE([], [],
+ 			has_option=yes,
+ 			has_option=no,)
+ 		if test $has_option = no; then
+ 			CFLAGS="$SAVE_CFLAGS"
++		else
++			CFLAGS="$SAVE_CFLAGS $option"
+ 		fi
+ 		AC_MSG_RESULT($has_option)
+ 		unset has_option
+ 		unset SAVE_CFLAGS
+ 	done
++	CFLAGS="$CFLAGS $WERROR"
+ 	unset option
+-	if test "x$set_more_warnings" = xerror; then
+-		CFLAGS="$CFLAGS -Werror"
+-	fi
++	unset WERROR
+ else
+ 	AC_MSG_RESULT(no)
+ fi
+-- 
+1.9.1
+

--- a/layers/meta-balena-compulab/recipes-connectivity/libqmi/libqmi_1.30.2.bb
+++ b/layers/meta-balena-compulab/recipes-connectivity/libqmi/libqmi_1.30.2.bb
@@ -1,0 +1,21 @@
+SUMMARY = "libqmi is a library for talking to WWAN devices by QMI protocol"
+DESCRIPTION = "libqmi is a glib-based library for talking to WWAN modems and \
+               devices which speak the Qualcomm MSM Interface (QMI) protocol"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/libqmi"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+DEPENDS = "glib-2.0 glib-2.0-native"
+
+inherit autotools pkgconfig bash-completion gobject-introspection
+
+SRC_URI = "http://www.freedesktop.org/software/${BPN}/${BPN}-${PV}.tar.xz"
+
+SRC_URI[sha256sum] = "be01ece0ea2c2194cbea5744bf5aaf06c04ba5fb7ec7887a13116c76d114fedd"
+
+PACKAGECONFIG ??= "udev mbim"
+PACKAGECONFIG[udev] = ",--without-udev,libgudev"
+PACKAGECONFIG[mbim] = "--enable-mbim-qmux,--disable-mbim-qmux,libmbim"

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/77-mm-huawei-configuration.rules
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/77-mm-huawei-configuration.rules
@@ -1,0 +1,11 @@
+# Copyright (c) 2013 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+# This file specifies udev rules to configure certain Huawei modems to select
+# the USB configuration expected by Chrome OS.
+# Huawei ME936: Select the MBIM configuration
+ACTION=="add|change", SUBSYSTEM=="usb", \
+  ENV{DEVTYPE}=="usb_device|usb_interface", \
+  ATTRS{idVendor}=="12d1", ATTRS{idProduct}=="15bb", \
+  ATTRS{bNumConfigurations}=="3", ATTRS{bConfigurationValue}!="3", \
+  RUN+="/lib/udev/mm-huawei-configuration-switch.sh %E{DEVTYPE} %S%p 3"

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/77-mm-u-blox-modeswitch.rules
@@ -1,0 +1,5 @@
+ACTION!="add|change", GOTO="modeswitch_rules_end"
+
+KERNEL=="ttyACM*", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="1146", TAG+="systemd", ENV{SYSTEMD_WANTS}="u-blox-switch@%E{DEVNAME}.service"
+
+LABEL="modeswitch_rules_end"

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/ModemManager.conf.systemd
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/ModemManager.conf.systemd
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/ModemManager --log-journal
+Restart=always
+RestartSec=10s

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch
@@ -1,0 +1,53 @@
+From 91ed72aa29ede06d3a5115128e2267793ca611d4 Mon Sep 17 00:00:00 2001
+From: "Bruce A. Johnson" <waterfordtrack@gmail.com>
+Date: Wed, 22 Dec 2021 14:24:02 -0500
+Subject: [PATCH] core: switch bash shell scripts to use /bin/sh for use
+ w/Busybox.
+
+Fixes https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/483
+---
+ data/fcc-unlock/105b           | 2 +-
+ data/fcc-unlock/1199           | 2 +-
+ data/fcc-unlock/1eac           | 2 +-
+ test/mmcli-test-sms            | 2 +-
+ tools/tests/test-wrapper.sh.in | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/data/fcc-unlock/105b b/data/fcc-unlock/105b
+index 21fe5329..f276050f 100644
+--- a/data/fcc-unlock/105b
++++ b/data/fcc-unlock/105b
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/data/fcc-unlock/1199 b/data/fcc-unlock/1199
+index 0109c6ab..e1d3804c 100644
+--- a/data/fcc-unlock/1199
++++ b/data/fcc-unlock/1199
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/data/fcc-unlock/1eac b/data/fcc-unlock/1eac
+index 1068d9c2..d9342852 100644
+--- a/data/fcc-unlock/1eac
++++ b/data/fcc-unlock/1eac
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/test/mmcli-test-sms b/test/mmcli-test-sms
+index 038d777d..8229d36a 100755
+--- a/test/mmcli-test-sms
++++ b/test/mmcli-test-sms
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+diff --git a/tools/tests/test-wrapper.sh.in b/tools/tests/test-wrapper.sh.in
+index d64ea4cb..fcdb56de 100644
+--- a/tools/tests/test-wrapper.sh.in
++++ b/tools/tests/test-wrapper.sh.in
+@@ -1 +1 @@
+-#!/bin/bash
++#!/bin/sh
+-- 
+2.35.1
+

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/mm-huawei-configuration-switch.sh
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/mm-huawei-configuration-switch.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Copyright (c) 2014 The Chromium OS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# $1 is either "usb_device" or "usb_interface" depending on what triggered this
+# script.
+# $2 is the full sysfs path to the device/interface.
+# $3 is the configuration mode number we switch the modem to
+
+switch_device_configuration() {
+  # expect:
+  #  $1 : sysfs path for the device.
+  #  $2 : the configuration mode number we switch the modem to
+  echo "$2" > "$1"/bConfigurationValue
+}
+
+if [ "$1" = "usb_device" ]
+then
+  switch_device_configuration "$2" "$3"
+else
+  switch_device_configuration "$(dirname "$2")" "$3"
+fi

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/u-blox-switch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+MODEM_TTY_PATH=$1
+
+# wait for the modem to be powered on
+while [ x`mmcli -m 0 --output-keyvalue 2>/dev/null | grep -i power-state | awk -F ": " '{ print $2 }'` != x"on" ] ; do sleep 1; done
+
+echo -e "AT+UUSBCONF=2,\"ECM\"\r\n" > $MODEM_TTY_PATH
+
+echo -e "AT+CFUN=1,1\r\n" > $MODEM_TTY_PATH

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/balena-files/u-blox-switch@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Switch u-blox modem from RNDIS to ECM mode
+Wants=ModemManager.service
+After=ModemManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/u-blox-switch.sh %I

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,0 +1,34 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/balena-files"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+SRC_URI_append = " \
+    file://77-mm-huawei-configuration.rules \
+    file://mm-huawei-configuration-switch.sh \
+    file://77-mm-u-blox-modeswitch.rules \
+    file://u-blox-switch@.service \
+    file://u-blox-switch.sh \
+    file://ModemManager.conf.systemd \
+"
+
+PACKAGECONFIG_remove = "polkit"
+
+do_install_append() {
+    install -d ${D}${base_libdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/77-mm-huawei-configuration.rules ${D}${base_libdir}/udev/rules.d/
+    install -m 0755 ${WORKDIR}/mm-huawei-configuration-switch.sh ${D}${base_libdir}/udev/
+    install -m 0644 ${WORKDIR}/77-mm-u-blox-modeswitch.rules ${D}${base_libdir}/udev/rules.d
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/u-blox-switch.sh ${D}${bindir}
+    install -d ${D}${systemd_unitdir}/system/ModemManager.service.d
+    install -m 0644 ${WORKDIR}/ModemManager.conf.systemd ${D}${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf
+    install -m 0644 ${WORKDIR}/u-blox-switch@.service ${D}${systemd_unitdir}/system
+}
+
+FILES_${PN} += " \
+    ${base_libdir}/udev/rules.d/77-mm-huawei-configuration.rules \
+    ${base_libdir}/udev/mm-huawei-configuration-switch.sh \
+    ${base_libdir}/udev/rules.d/77-mm-u-blox-modeswitch.rules \
+    ${systemd_unitdir}/system/u-blox-switch@.service \
+    ${bindir}/u-blox-switch.sh \
+    ${systemd_unitdir}/system/ModemManager.service.d/ModemManager.conf \
+    "

--- a/layers/meta-balena-compulab/recipes-connectivity/modemmanager/modemmanager_1.18.4.bb
+++ b/layers/meta-balena-compulab/recipes-connectivity/modemmanager/modemmanager_1.18.4.bb
@@ -1,0 +1,61 @@
+SUMMARY = "ModemManager is a daemon controlling broadband devices/connections"
+DESCRIPTION = "ModemManager is a DBus-activated daemon which controls mobile broadband (2G/3G/4G) devices and connections"
+HOMEPAGE = "http://www.freedesktop.org/wiki/Software/ModemManager/"
+LICENSE = "GPL-2.0 & LGPL-2.1"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
+"
+
+inherit gnomebase gettext systemd vala gobject-introspection bash-completion
+
+DEPENDS = "glib-2.0 libgudev dbus-glib intltool-native libxslt-native"
+
+SRC_URI = " \
+    http://www.freedesktop.org/software/ModemManager/ModemManager-${PV}.tar.xz \
+    file://core-switch-bash-shell-scripts-to-use-bin-sh-for-use.patch \
+"
+SRC_URI[sha256sum] = "11fb970f63e2da88df4b6d8759e4ee649944c515244b979bf50a7a6df1d7f199"
+
+
+S = "${WORKDIR}/ModemManager-${PV}"
+
+PACKAGECONFIG ??= "mbim qmi \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'systemd polkit', d)} \
+"
+
+PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_unitdir}/system/,,"
+PACKAGECONFIG[polkit] = "--with-polkit=yes,--with-polkit=no,polkit"
+# Support WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol.
+PACKAGECONFIG[mbim] = "--with-mbim,--without-mbim,libmbim"
+# Support WWAN modems and devices which speak the Qualcomm MSM Interface (QMI) protocol.
+PACKAGECONFIG[qmi] = "--with-qmi,--without-qmi,libqmi"
+
+EXTRA_OECONF = " \
+    --with-udev-base-dir=${nonarch_base_libdir}/udev \
+    --with-at-command-via-dbus=yes \
+"
+
+EXTRA_OECONF_append_toolchain-clang = " --enable-more-warnings=no"
+
+FILES_${PN} += " \
+    ${datadir}/icons \
+    ${datadir}/polkit-1 \
+    ${datadir}/dbus-1 \
+    ${datadir}/ModemManager \
+    ${libdir}/ModemManager \
+    ${systemd_unitdir}/system \
+"
+
+FILES_${PN}-dev += " \
+    ${libdir}/ModemManager/*.la \
+"
+
+FILES_${PN}-staticdev += " \
+    ${libdir}/ModemManager/*.a \
+"
+
+FILES_${PN}-dbg += "${libdir}/ModemManager/.debug"
+
+SYSTEMD_SERVICE_${PN} = "ModemManager.service"
+


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/meta-balena/pull/3184

We do so because the MM update in meta-balena linked above won't work with
Meson older than 0.53.0. See internal discussion https://balena.zulipchat.com/#narrow/stream/345889-balena-io.2Fos/topic/Compulab.20IOT-gate-imx8/near/374666230
