### PR TITLE
linux-imx: fix compilation with gcc-10

### DIFF
--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx/0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch
@@ -1,0 +1,47 @@
+From: Dirk Mueller <dmueller@suse.com>
+Date: Tue, 14 Jan 2020 18:53:41 +0100
+Subject: [PATCH] scripts/dtc: Remove redundant YYLOC global declaration
+
+gcc 10 will default to -fno-common, which causes this error at link
+time:
+
+  (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+
+This is because both dtc-lexer as well as dtc-parser define the same
+global symbol yyloc. Before with -fcommon those were merged into one
+defintion. The proper solution would be to to mark this as "extern",
+however that leads to:
+
+  dtc-lexer.l:26:16: error: redundant redeclaration of 'yylloc' [-Werror=redundant-decls]
+   26 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+In file included from dtc-lexer.l:24:
+dtc-parser.tab.h:127:16: note: previous declaration of 'yylloc' was here
+  127 | extern YYLTYPE yylloc;
+      |                ^~~~~~
+cc1: all warnings being treated as errors
+
+which means the declaration is completely redundant and can just be
+dropped.
+
+Signed-off-by: Dirk Mueller <dmueller@suse.com>
+Signed-off-by: David Gibson <david@gibson.dropbear.id.au>
+[robh: cherry-pick from upstream]
+Cc: stable@vger.kernel.org
+Signed-off-by: Rob Herring <robh@kernel.org>
+---
+ scripts/dtc/dtc-lexer.l | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 5c6c3fd557d7..b3b7270300de 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -23,7 +23,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
+++ b/layers/meta-balena-compulab/recipes-kernel/linux/linux-imx_4.14.%.bbappend
@@ -10,6 +10,7 @@ SRC_URI_append = " \
         file://USB3-stability-fix.patch \
         file://0001-Add-support-for-NXP-PCA9956B-LED-controller.patch \
         file://0024-Send-a-uevent-on-the-pwmchip-device-upon-channel-sysfs-export.patch \
+        file://0001-scripts-dtc-Remove-redundant-YYLOC-global-declaratio.patch \
 "
 
 SRC_URI_append_etcher-pro = " \


### PR DESCRIPTION
Newer gcc versions are used when building the kernel for the kernel-header-test packages in newer meta-balena versions.

Changelog-entry: fix linux-imx compilation for gcc-10